### PR TITLE
Critical fix for option(s) generation + A variety of QoL updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # Project TODO List
-## Last updated Wed Apr 01 21:45:39 2026 UTC
+## Last updated 2026-04-09T19:49:40.333-04:00
 
 ### Priority
 - High
@@ -16,18 +16,27 @@
 ### Dates
 - Dates are to be inserted using the ISO 8601 standard to avoid international confusion.
 - See: [ISO 8601 Date Generator](https://developertoolskit.com/tools/iso-date-generator)
-    - Howto:
+    - Updating the "Last updated" label:
         - Click "Use system time"
+        - Click "Include time information (hh:mm:ss)"
+        - Click "Include timezone information (Z)"
+        - Click "Generate ISO 8601 Data" 
+        - Copy the generated timestamp under "ISO 8601 Date"
+
+    - Updating the "Date Assigned" or "Date Completed":
+        - Click "Use system time"
+        - Disable "Include time information (hh:mm:ss)"
+        - Disable "Include timezone information (Z)"
         - Click "Generate ISO 8601 Data" 
         - Copy the generated timestamp under "ISO 8601 Date"
 
 | Task ID | Task Description | Priority | Status | Assigned To | Date Assigned | Date Completed
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| T-001 | Fix the dual recursion bug in `convert_sourcetree_to_cmake` | High | Pending Review | @Static-Codes | 2026-03-31 | 2026-04-01 |
+| T-001 | Fix the dual recursion bug in `convert_sourcetree_to_cmake` | High | Completed | @Static-Codes | 2026-03-31 | 2026-04-01 |
 | T-002 | Improve the variable expansion logic for `_SOURCES` | Low | Unassigned | TBD | N/A | N/A |
 | T-003 | Add support for QMake's `subdirs` project type | Low | Unassigned | TBD | N/A | N/A |
 | T-004 | Refine the configuration file parsing logic | Low | Unassigned | TBD | N/A | N/A |
 | T-005 | Update minimum version pinning of CMake (3.X) | Low | Unassigned | TBD | N/A | N/A |
 | T-006 | Address the `# FIX THIS` comments | Low | Unassigned | TBD | N/A | N/A |
-| T-007 | Implement `get_cmake_version()` | Low | @Static-Codes | TBD | N/A | N/A |
+| T-007 | Implement `get_cmake_version()` | Low | @Static-Codes | TBD | 2026-04-08 | 2026-04-09 |
 | T-008 | Rename `remove_garbage()` to `sanitize_string()` | TBD | N/A | N/A |

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # Project TODO List
-## Last updated 2026-04-09T19:49:40.333-04:00
+## Last updated 2026-04-10T21:51:42.081-04:00
 
 ### Priority
 - High
@@ -36,7 +36,7 @@
 | T-002 | Improve the variable expansion logic for `_SOURCES` | Low | Unassigned | TBD | N/A | N/A |
 | T-003 | Add support for QMake's `subdirs` project type | Low | Unassigned | TBD | N/A | N/A |
 | T-004 | Refine the configuration file parsing logic | Low | Unassigned | TBD | N/A | N/A |
-| T-005 | Update minimum version pinning of CMake (3.X) | Low | Unassigned | TBD | N/A | N/A |
+| T-005 | Update minimum version pinning of CMake (3.X) | Low | @fritzone | Assigned | 2026-04-10 | N/A |
 | T-006 | Address the `# FIX THIS` comments | Low | Unassigned | TBD | N/A | N/A |
-| T-007 | Implement `get_cmake_version()` | Low | @Static-Codes | TBD | 2026-04-08 | 2026-04-09 |
+| T-007 | Implement `get_cmake_version()` | Low | @Static-Codes | Pending Review | 2026-04-08 | 2026-04-09 |
 | T-008 | Rename `remove_garbage()` to `sanitize_string()` | TBD | N/A | N/A |

--- a/TODO.md
+++ b/TODO.md
@@ -29,4 +29,5 @@
 | T-004 | Refine the configuration file parsing logic | Low | Unassigned | TBD | N/A | N/A |
 | T-005 | Update minimum version pinning of CMake (3.X) | Low | Unassigned | TBD | N/A | N/A |
 | T-006 | Address the `# FIX THIS` comments | Low | Unassigned | TBD | N/A | N/A |
-| T-007 | Implement `get_cmake_version()` | Low | Unassigned | TBD | N/A | N/A |
+| T-007 | Implement `get_cmake_version()` | Low | @Static-Codes | TBD | N/A | N/A |
+| T-008 | Rename `remove_garbage()` to `sanitize_string()` | TBD | N/A | N/A |

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -48,7 +48,9 @@ class CMakeVersion:
         
         self.major: int = None
         self.minor: int = None
-        self.build: int = None
+        
+        # Since the build version is not always specified, defaulting it to 0 will avoid AttributeError(s)
+        self.build: int = 0 
 
         # Initializing the major, minor, and build versions
         self.__parse__(version_string)
@@ -310,7 +312,7 @@ qrc_extensions = [".qrc"]
 ########################################################################################################################
 # Checks for an installation of CMake and attempts to resolve the version installed.
 ########################################################################################################################
-def get_installed_cmake_version():
+def get_installed_cmake_version() -> Optional[CMakeVersion]:
     print(f"Checking for a CMake installation, please wait.")
     print()
         
@@ -320,7 +322,7 @@ def get_installed_cmake_version():
         sys.exit()
     
 
-    result = None
+    match = None
     
     try:
         result = subprocess.run(
@@ -329,30 +331,70 @@ def get_installed_cmake_version():
             text=True,
             check=True
         )
+        # Checking for the expected output of:
+        # "cmake version X.X.X" or "cmake3 version X.X.X"
+        # Upon further research, "cmake" is sometimes a symlink to cmake3 on certain linux distributions.
+        # https://stackoverflow.com/questions/50989957/whats-the-difference-between-cmake-vs-cmake3
+        match = re.search(r"version\s+([\d.]+)", result.stdout)
+        
+        if not match:
+            print(
+                f"CMake detected, but the version string could not be parsed.\nOutput: {result.stdout}"
+            )
+            exit(1)
+
+
+        print(f"CMake {match.group(1)} is installed.")
+
     except Exception as e:
         print("A CMake installation was found, however, an unexpected response was received.")
         print(f"Response:\n{e.stderr}")
-
-    # Checking for the expected output of:
-    # "cmake version X.X.X" or "cmake3 version X.X.X"
-    # Upon further research, "cmake" is sometimes a symlink to cmake3 on certain linux distributions.
-    # https://stackoverflow.com/questions/50989957/whats-the-difference-between-cmake-vs-cmake3
-    match = re.search(r"version\s+([\d.]+)", result.stdout)
+        return None
     
-    if not match:
-        print(
-            f"CMake detected, but the version string could not be parsed.\nOutput: {result.stdout}"
-        )
-        exit(1)
+    return CMakeVersion(match.group(1))
+    
 
+########################################################################################################################
+# Performs a comparison operation on two CMakeVersion objects.
+# Returns True if lower_version_obj is greater than higher_version_obj when both objects are parsed.
+# Returns False otherwise.
+########################################################################################################################
+def cmake_version_is_invalid(lower_version_obj: CMakeVersion, higher_version_obj: CMakeVersion) -> bool:
+    # Handling the major and minor versions of both CMakeVersion objects passed as parameters.
+    if (
+        lower_version_obj.major is None or
+        higher_version_obj.major is None or
+        lower_version_obj.minor is None or
+        higher_version_obj.minor is None
+    ):
+        return True
 
-    print(f"CMake {match.group(1)} is installed.")
-    return match.group(1)
+    elif (
+        lower_version_obj.major > higher_version_obj.major or 
+
+        lower_version_obj.major >= higher_version_obj.major and
+        lower_version_obj.minor > higher_version_obj.minor
+    ):
+        return True
+
+    # Handling the build versions of both CMakeVersion objects passed as parameters.    
+    elif (
+        lower_version_obj.major >= higher_version_obj.major and
+        lower_version_obj.minor >= higher_version_obj.minor and
+        lower_version_obj.build > higher_version_obj.build
+    ):
+        return True
+
+    return False
+
 
 ########################################################################################################################
 # Validates the value for the arguments "-v <VERSION>" and --version="<VERSION>"
 ########################################################################################################################
 def validate_cmake_version(provided_version: str, latest_version: Optional[str]):
+    global cmake_installed_version
+    global cmake_minimum_version
+
     if latest_version is None:
         print("Unable to resolve the latest version of CMake.")
         return
@@ -360,31 +402,39 @@ def validate_cmake_version(provided_version: str, latest_version: Optional[str])
     try:
         provided_version_obj: CMakeVersion = CMakeVersion(provided_version)
         latest_version_obj: CMakeVersion = CMakeVersion(latest_version)
-        
-        # Handles versions that are less than CMake 2.0
-        if provided_version_obj.major < 2:
-            print(f"The specified version of CMake (v{provided_version_obj}) is not supported by auto2cmake.")
-            print("Please specify a version at or greater than CMake 2.8")
-            exit(1)
 
-        # Handles versions that are between CMake 2.0 and CMake 2.7
-        elif provided_version_obj.major == 2 and provided_version_obj.minor < 8:
+        # Handles versions that are less than the minimum supported
+        if (cmake_version_is_invalid(cmake_minimum_version, provided_version_obj)):
             print(f"The specified version of CMake (v{provided_version_obj}) is not supported by auto2cmake.")
-            print("Please specify a version at or greater than CMake 2.8")
+            print(f"Please specify a version at or greater than CMake {cmake_minimum_version}")
             exit(1)
 
         # Handles versions that are not released (also handles incorrect input)
-        elif provided_version_obj.major > latest_version_obj.major:
+        elif (cmake_version_is_invalid(provided_version_obj, latest_version_obj)):
             print("The specified version of CMake is not currently released.")
             print(f"The latest public release is v{latest_version_obj}")
             exit(1)
 
+        # General null check
+        elif (not provided_version_obj or not cmake_installed_version):
+            print("The following parameter has a NoneType in validate_cmake_version:")
+            print("\tprovided_version_obj" if not provided_version_obj else "\tcmake_installed_version")
+            exit(1)
+
+        # Currently a warning is provided when the installed version of CMake is older than version specified via flag.
+        elif (cmake_version_is_invalid(provided_version_obj, cmake_installed_version)):
+            print(f"The specified version of CMake (v{provided_version_obj}) is newer than the installed version on the current system.")
+            warning(
+                "This may cause unexpected behavior.\n"
+                f"It is recommended to specify {cmake_installed_version} instead of {provided_version_obj}"
+            )
+
         else:
             print(f"Validation complete, all processing will be done using CMake {provided_version_obj}")
-        
+            
 
     except Exception as e:
-        print(f"Error resolving the latest version of CMake.")
+        print(f"Error validating the provided version of CMake.")
         print(f"Type: {type(e)}")
         print(f"Error: {e}")
         print("Skipping version validation.")
@@ -419,11 +469,10 @@ def update_version_info():
     global cmake_maximum_version
     global cmake_installed_version
 
-    # retrieving the latest version of CMake from their official Github repository
-    # the maximimum version of CMake currently released. validate_cmake_version
+    # The maximimum version of CMake currently released.
     cmake_maximum_version = get_latest_cmake_version()
 
-    # the currently installed version of CMake on the System. Exits if CMake is not detected.
+    # The currently installed version of CMake on the System. Exits if CMake is not detected.
     cmake_installed_version = get_installed_cmake_version()
 
 # prints a warning message
@@ -1984,7 +2033,6 @@ def usage():
 # main
 ########################################################################################################################
 def main(argv):
-
     global working_directory
     global exclude_directories
     global quick
@@ -2017,7 +2065,7 @@ def main(argv):
         # Handles both "-d <dir>" and "--directory=<dir>"
         elif opt == "-d" or opt == "--directory":
             working_directory = os.path.expanduser(arg)
-            print("Start in: {}".format(working_directory))
+            print("Starting execution in directory: {}".format(working_directory))
         
         # Handles directory exclusion
         elif opt == "-e" or opt == "--exclude":
@@ -2041,9 +2089,10 @@ def main(argv):
 
         elif opt == "-v" or opt == "--version":
             print(f"CMake {cmake_maximum_version} is the latest.")
-            print(f"CMake {arg} specified via flag.")
+            print(f"CMake {arg} was specified via flag.")
             print()
-            print("Validating input, please wait.")
+            print(f"Checking if auto2cmake supports CMake {arg}, please wait.")
+            print()
             validate_cmake_version(provided_version=arg, latest_version=cmake_maximum_version.full_version)
             cmake_minimum_version = CMakeVersion(arg)
 

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -242,9 +242,9 @@ def replace_quotes(a):
 
 
 def get_library_for_name(name):
-    for l in libraries:
-        if l.canonic_name == name:
-            return l
+    for library in libraries:
+        if library.canonic_name == name:
+            return library
     return None
 
 ########################################################################################################################

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -1,4 +1,7 @@
 #!/usr/bin/python3
+########################################################################################################################
+#                                               Application Description                                                #
+########################################################################################################################
 # script to convert an autotools project to more or less corresponding CMakeLists.txt structure
 # Interpret the linker flags
 # interpret the programs, generate add_executable
@@ -6,68 +9,27 @@
 # the gather the files mode
 # include directory generation based on parsing the file for #include
 
-import sys, getopt, time, os, re, glob, subprocess, shutil
+
+########################################################################################################################
+#                                                   Application Imports                                                #
+########################################################################################################################
+import sys, getopt, time, os, re, glob, shutil, subprocess
 from difflib import SequenceMatcher
 from enum import Enum
 from os.path import join as pjoin
+from urllib import request # urllib is chosen over requests to maintain portability
+from json import loads
+from typing import List, Optional # Used for explicit type declarations. (helpful for analyzing types without an IDE)
 
-########################################################################################################################
-#                 Global variables used by the application, specified on command line                                  #
-########################################################################################################################
 
-#
-# whether this is a quick conversion
-quick = False
-# whether the quick conversion is recursive or not
-recursive = False
-# whether the quick conversion generates a library or an executable
-quick_gen_lib = True
-# whether to use CMakes AUTOMOC or manually generate the moc files
-cmake_automoc = True
-
-# all the options should be upcase? -u switch
-upcase_identifiers = 1
-# should we generate some coments in the CMakeLists.txt? -c switch
-generate_comments = 1
-# generate more empty lines in the output file. -n switch
-more_newlines = 1
-# The working directory. Will be set by the -d argument to the script
-working_directory = "."
-# these directories will be excluded when searching for Makefile.am's (or any other processing). -e is the argument
-exclude_directories = []
-
-########################################################################################################################
-#                                       The application logic structures                                               #
-########################################################################################################################
-
-# the list of libraries that will be built. contains Library objects
-libraries = []
-# will contain all the options that were gathered from configure.ac in form of Option objects
-options = {}
-# will contain all the defines from the configure.ac
-temp_defines = {}
-# will contain the CMakeLists of the converted system. Key is the directory
-cmake_files = {}
-# will contain all the variables defined in configure.ac
-config_ac_variables = {}
-# will hold extra content for CMakeLists in specific directories
-extra_content = {}
-# The list of all the directories that will need a CMakeLists.txt in them
-required_directories = []
-
-########################################################################################################################
-# Constants
-########################################################################################################################
-cpp_extensions = [".c", ".cpp", ".cxx", ".c++", ".cc"]
-header_extensions = [".h", ".hpp", ".hxx", ".h++", ".hh"]
-qrc_extensions = [".qrc"]
 
 ########################################################################################################################
 #                                       Classes used by the application                                                #
 ########################################################################################################################
 
+
 ########################################################################################################################
-# represents a cmake file that will be generated at a later stage
+# Represents a CMake file that will be generated at a later stage.
 ########################################################################################################################
 class CMakeFile:
     def __init__(self, directory):
@@ -76,15 +38,58 @@ class CMakeFile:
         self.libraries = []                         # All the libraries that are created by this file
         self.extra_content = ""                     # Extra stuff such as add_subdriectory
 
+
 ########################################################################################################################
-# Whether a target is a library (noinst_LIBRARIES) or an application (bin_PROGRAMS)
+# Represents a CMake version object that will be utilized prior to, and during the generation stages.
+########################################################################################################################
+class CMakeVersion:
+    def __init__(self, version_string: str):
+        self.full_version: str = version_string
+        
+        self.major: int = None
+        self.minor: int = None
+        self.build: int = None
+
+        # Initializing the major, minor, and build versions
+        self.__parse__(version_string)
+
+
+    def __parse__(self, version_string: Optional[str]):
+        if version_string is None:
+            print("No CMake version string provided. Expected format: 'X.X' or 'X.X.X'")
+            exit(1)
+
+        version_parts: List[int] = [int(part) for part in version_string.split('.') if part.isdigit()]
+        number_of_parts: int = len(version_parts)
+
+        if number_of_parts in [0, 1] or number_of_parts > 3:
+            print("Unable to parse the provided CMake version string. Expected format: 'X.X' or 'X.X.X'")
+            exit(1)
+        
+        # Covering the major and minor version numbers
+        if number_of_parts >= 2:
+            self.major = version_parts[0]
+            self.minor = version_parts[1]
+        
+        # Since this class will not be called more than a handful of times, this additional check:
+        # - Covers the build version number
+        # - Uses a neglible amount of memory
+        # - Improves readability for future maintainers
+        if number_of_parts == 3:
+            self.build = version_parts[2]
+
+    def __str__(self):
+        return self.full_version
+
+########################################################################################################################
+# Whether a target is a Library (noinst_LIBRARIES) or an Application (bin_PROGRAMS)
 ########################################################################################################################
 class TargetType(Enum):
     LIBRARY = 1
     PROGRAM = 2
 
 ########################################################################################################################
-# represents a library that will be built by a specific make command
+# Represents a library that will be built by a specific make command.
 ########################################################################################################################
 class Library:
     def __init__(self, name, directory):
@@ -126,7 +131,7 @@ class Library:
 
 
 ########################################################################################################################
-# represents an option that will go in the CMakeLists.txt and also in the generated header if has a define
+# Represents an option that will go in the CMakeLists.txt and also in the generated header if a define is present.
 ########################################################################################################################
 class Option:
 
@@ -202,10 +207,229 @@ class Option:
 
 
 ########################################################################################################################
+#                 Global variables used by the application, specified on command line                                  #
+########################################################################################################################
+
+
+# Whether auto2cmake should utilize its "Quick Mode" for the next conversion.
+quick = False
+
+# Whether "Quick Mode" should utilize recursive directory walking for the next conversion.
+recursive = False
+
+# Whether "Quick Mode should generate a library or an executable. 
+# True => Library
+# False => Executable
+quick_gen_lib = True
+
+# Whether auto2cmake should use CMakes AUTOMOC.
+# If set to False, auto2cmake will use QT source wrapping to manually generate these moc files.
+cmake_automoc = True
+
+# Whether auto2cmake should use uppercase identifers for option objects.
+upcase_identifiers = 1
+
+# Whether the generated "CMakeLists.txt" files should contain optional comments.
+# This can be disabled by passing either "-c" or "--disable-comments"
+# It is recommended to leave this enabled.
+# 0 => Disable Comments
+# 1 => Enable Comments
+generate_comments = 1
+
+# Whether the generated "CMakeLists.txt" files should append more new than one newline char (\n) after each generated line. 
+# 0 => Don't add an extra new line character (\n) after each generated line.
+# 1 => Add an extra new line character (\n) after each generated line.
+more_newlines = 1
+
+# The working directory for the conversion operations attempted by auto2cmake. 
+# By default, auto2cmake will search the same directory the script is ran from.
+# This can be changed by passing either "-d <dir>" or "--directory=<dir>" 
+working_directory = "."
+
+# The directories auto2cmake should exclude when searching for Makefile.am(s) and during any other processing.
+# By default, auto2cmake does not exclude any directories.
+# This can be changed by passing any of the following:
+# "-e <dir>"
+# "--exclude=<dir>"
+# "--exclude=<dir1>:<dir2>:<dir3>"
+exclude_directories = []
+
+
+#######################################################################################################################
+#                                          CMake Version Info                                                         #
+#                               These values will be updated in update_version_info()                                 #
+#######################################################################################################################
+# The minimum version of CMake the converted project will support
+# The default version for conversion operations is CMake 2.8
+# This can be changed by passing either "-v <version>" or "--version=<version>"
+cmake_minimum_version: CMakeVersion = CMakeVersion("2.8")
+
+# The maximimum version of CMake currently released. 
+# Utilized in validate_cmake_version()
+cmake_maximum_version: Optional[CMakeVersion] = None
+
+# The currently installed version of CMake on the current machine.
+# Currently this has no impact on execution, despite being declared in update_version_info().
+# T-007 in TODO seeks to address this.
+cmake_installed_version: Optional[CMakeVersion] = None
+
+
+########################################################################################################################
+#                                       The application logic structures                                               #
+########################################################################################################################
+
+# the list of libraries that will be built. contains Library objects
+libraries = []
+# will contain all the options that were gathered from configure.ac in form of Option objects
+options = {}
+# will contain all the defines from the configure.ac
+temp_defines = {}
+# will contain the CMakeLists of the converted system. Key is the directory
+cmake_files = {}
+# will contain all the variables defined in configure.ac
+config_ac_variables = {}
+# will hold extra content for CMakeLists in specific directories
+extra_content = {}
+# The list of all the directories that will need a CMakeLists.txt in them
+required_directories = []
+
+########################################################################################################################
+# Constants
+########################################################################################################################
+cpp_extensions = [".c", ".cpp", ".cxx", ".c++", ".cc"]
+header_extensions = [".h", ".hpp", ".hxx", ".h++", ".hh"]
+qrc_extensions = [".qrc"]
+
+
+
+
+########################################################################################################################
 #                                       Helper functions used by the application                                       #
 ########################################################################################################################
 
 ########################################################################################################################
+# Checks for an installation of CMake and attempts to resolve the version installed.
+########################################################################################################################
+def get_installed_cmake_version():
+    print(f"Checking for a CMake installation, please wait.")
+    print()
+        
+    # Checking for the existence of "cmake" in the current system's path.
+    if not shutil.which("cmake"):
+        print("CMake installation not found. Please install CMake and try again.")
+        sys.exit()
+    
+
+    result = None
+    
+    try:
+        result = subprocess.run(
+            ["cmake", "--version"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except Exception as e:
+        print("A CMake installation was found, however, an unexpected response was received.")
+        print(f"Response:\n{e.stderr}")
+
+    # Checking for the expected output of:
+    # "cmake version X.X.X" or "cmake3 version X.X.X"
+    # Upon further research, "cmake" is sometimes a symlink to cmake3 on certain linux distributions.
+    # https://stackoverflow.com/questions/50989957/whats-the-difference-between-cmake-vs-cmake3
+    match = re.search(r"version\s+([\d.]+)", result.stdout)
+    
+    if not match:
+        print(
+            f"CMake detected, but the version string could not be parsed.\nOutput: {result.stdout}"
+        )
+        exit(1)
+
+
+    print(f"CMake {match.group(1)} is installed.")
+    return match.group(1)
+
+########################################################################################################################
+# Validates the value for the arguments "-v <VERSION>" and --version="<VERSION>"
+########################################################################################################################
+def validate_cmake_version(provided_version: str, latest_version: Optional[str]):
+    if latest_version is None:
+        print("Unable to resolve the latest version of CMake.")
+        return
+
+    try:
+        provided_version_obj: CMakeVersion = CMakeVersion(provided_version)
+        latest_version_obj: CMakeVersion = CMakeVersion(latest_version)
+        
+        # Handles versions that are less than CMake 2.0
+        if provided_version_obj.major < 2:
+            print(f"The specified version of CMake (v{provided_version_obj}) is not supported by auto2cmake.")
+            print("Please specify a version at or greater than CMake 2.8")
+            exit(1)
+
+        # Handles versions that are between CMake 2.0 and CMake 2.7
+        elif provided_version_obj.major == 2 and provided_version_obj.minor < 8:
+            print(f"The specified version of CMake (v{provided_version_obj}) is not supported by auto2cmake.")
+            print("Please specify a version at or greater than CMake 2.8")
+            exit(1)
+
+        # Handles versions that are not released (also handles incorrect input)
+        elif provided_version_obj.major > latest_version_obj.major:
+            print("The specified version of CMake is not currently released.")
+            print(f"The latest public release is v{latest_version_obj}")
+            exit(1)
+
+        else:
+            print(f"Validation complete, all processing will be done using CMake {provided_version_obj}")
+        
+
+    except Exception as e:
+        print(f"Error resolving the latest version of CMake.")
+        print(f"Type: {type(e)}")
+        print(f"Error: {e}")
+        print("Skipping version validation.")
+        return
+
+########################################################################################################################
+# Resolves the latest version of CMake from https://github.com/Kitware/CMake
+########################################################################################################################
+def get_latest_cmake_version():
+    url = "https://api.github.com/repos/Kitware/CMake/releases"
+    version = None
+    json_data = None
+
+    try:
+        with request.urlopen(url) as req:
+            str_data = req.read().decode('utf-8')
+            json_data = loads(str_data)
+            version = json_data[0]["tag_name"][1:]
+
+    except Exception as e:
+        print(e)
+
+    if not json_data:
+        print("Unable to resolve the latest version of CMake.")
+    
+    return CMakeVersion(version)
+
+########################################################################################################################
+# Updates the CMake version information used by the application.
+########################################################################################################################
+def update_version_info():
+    global cmake_maximum_version
+    global cmake_minimum_version
+    global cmake_installed_version
+
+    # the minimum version of CMake the converted project will support
+    cmake_minimum_version = "2.8"
+
+    # retrieving the latest version of CMake from their official Github repository
+    # the maximimum version of CMake currently released. validate_cmake_version
+    cmake_maximum_version = get_latest_cmake_version()
+
+    # the currently installed version of CMake on the System. Exits if CMake is not detected.
+    cmake_installed_version = get_installed_cmake_version()
+
 # prints a warning message
 ########################################################################################################################
 def warning(*s):
@@ -262,47 +486,6 @@ def should_exclude(dire):
         if dire.startswith(exc_dir):
             return True
     return False
-
-########################################################################################################################
-# Checks for an installation of CMake and attempts to resolve the version installed.
-########################################################################################################################
-def get_cmake_version():
-    print(f"Checking for a CMake installation please wait.")
-    
-    # Checking for the existence of "cmake" in the current system's path.
-    if not shutil.which("cmake"):
-        print("CMake installation not found. Please install CMake and try again.")
-        sys.exit()
-
-    result = None
-    
-    try:
-        result = subprocess.run(
-            ["cmake", "--version"],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-    except Exception as e:
-        print("A CMake installation was found, however, an unexpected response was received.")
-        print(f"Response:\n{e.stderr}")
-
-
-    
-
-    # Checking for the expected output of:
-    # "cmake version X.X.X" or "cmake3 version X.X.X"
-    # Upon further research, "cmake" is sometimes a symlink to cmake3 on certain linux distributions.
-    # https://stackoverflow.com/questions/50989957/whats-the-difference-between-cmake-vs-cmake3
-    match = re.search(r"version\s+([\d.]+)", result.stdout)
-    
-    if not match:
-        print(
-            f"CMake detected, but the version string could not be parsed.\nOutput: {result.stdout}"
-        )
-        sys.exit()
-
-    return match.group(1)
 
 
 ########################################################################################################################
@@ -954,7 +1137,7 @@ def process_libraries():
 
 
 ########################################################################################################################
-# Makes a cmake internal library name from what comes in
+# Makes a CMake internal library name from what comes in
 ########################################################################################################################
 def make_nice_library_name(link_name):
     link_name = link_name.replace("'", "")
@@ -1140,7 +1323,7 @@ def generate_default_cmake(req_dir):
     sources += ")\n"
 
     r_cmake_file = open(req_dir + "/CMakeLists.txt", "w")
-    r_cmake_file.write("cmake_minimum_required(VERSION 2.8)\n")
+    r_cmake_file.write(f"cmake_minimum_required(VERSION {cmake_minimum_version})\n")
     if has_code:
         r_cmake_file.write(sources)
         r_cmake_file.write("add_library(${project} STATIC ${${project}_SOURCES} )")
@@ -1193,7 +1376,7 @@ def create_cmakefile(path, cpps, headers, module):
 
     f = open(pjoin(path,"CMakeLists.txt"), "w+")
 
-    f.write("cmake_minimum_required(VERSION 2.8)\n")
+    f.write(f"cmake_minimum_required(VERSION {cmake_minimum_version})\n")
     if full_module:
         f.write("set (project " + full_module + ")\n\n")
     else:
@@ -1456,7 +1639,7 @@ def convert_qmake_project(dir, fn):
 
     cmake_file = open(dir + "/CMakeLists.txt", "w")
     cmake_file.write("# Autogenerated by auto2cmake on {0}\n\n".format(time.strftime("%Y-%m-%d %H:%M:%S")))
-    cmake_file.write("cmake_minimum_required(VERSION 2.8)\n\n")
+    cmake_file.write(f"cmake_minimum_required(VERSION {cmake_minimum_version})\n\n")
     
     # Per https://cmake.org/cmake/help/latest/command/project.html#usage
     # 'project(${project})' goes after 'cmake_minimum required' and before 'set(project "name")'
@@ -1580,6 +1763,7 @@ def convert_qmake_project(dir, fn):
 def convert():
 
     global working_directory
+    global cmake_minimum_version
 
     # If this is a quick conversion mode:
     # 1. Just gather the cpp files in the current directory
@@ -1616,8 +1800,8 @@ def convert():
         cmake_file.write("# Autogenerated by auto2cmake on {0}\n\n# Options\n\n".
                          format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
-    # let's not be very cmake hungry
-    cmake_file.write("cmake_minimum_required(VERSION 2.8)\n")
+    # Supports CMake 2.8+
+    cmake_file.write(f"cmake_minimum_required(VERSION {cmake_minimum_version})\n")
 
     project_working_directory = os.path.basename(os.path.normpath(working_directory))
     cmake_file.write("project({0})\n".format(project_working_directory))
@@ -1755,13 +1939,13 @@ def usage():
     )
 
     print(
-        "2.    [ -d | --directory=<dir> ]\n"
+        "2.    [ -d <dir> | --directory=<dir> ]\n"
         "\tBy default, auto2cmake uses the current working directory for execution.\n"
         "\tBy passing this flag the working directory will be changed to reflect the provided directory.\n"
     )
 
     print(
-        "3.    [ -e | --exclude=<dir1> | --exclude=<dir1:dir2:etc> ]\n"
+        "3.    [ -e <dir> | --exclude=<dir1> | --exclude=<dir1:dir2:etc> ]\n"
         "\tBy passing this flag the provided directories will be skipped during execution.\n"
     )
 
@@ -1794,6 +1978,12 @@ def usage():
         "\tIf Quick Mode is enabled, this flag won't change any behavior.\n"
     )
 
+    print(
+        "8.    [ -v <version> | --version=<version> ]\n"
+        "\tBy default auto2cmake pins minimum version support to CMake 2.8+\n"
+        "\tBy passing this flag, auto2cmake will use the specified version.\n"
+    )
+
 ########################################################################################################################
 # main
 ########################################################################################################################
@@ -1805,12 +1995,16 @@ def main(argv):
     global recursive
     global cmake_automoc
     global generate_comments
+    global cmake_maximum_version
+    
+    # Updating the CMake version info prior to handling arguments to ensure the values are properly set.
+    update_version_info()
 
     try:
         opts, args = getopt.getopt(
             argv, 
-            shortopts="d:e:hqrac", 
-            longopts=["directory=", "exclude=", "help", "quick", "recursive" , "automoc", "disable-comments"]
+            shortopts="d:e:v:hqrac", 
+            longopts=["directory=", "exclude=", "version=", "help", "quick", "recursive" , "automoc", "disable-comments"]
         )
 
     except getopt.GetoptError:
@@ -1847,6 +2041,14 @@ def main(argv):
         # Disables optional comment generation.
         elif opt == "-c" or opt == "--disable-comments":
             generate_comments = 0
+
+        elif opt == "-v" or opt == "--version":
+            print(f"CMake {cmake_maximum_version} is the latest.")
+            print(f"CMake {arg} specified via flag.")
+            print()
+            print("Validating input, please wait.")
+            validate_cmake_version(provided_version=arg, latest_version=cmake_maximum_version.full_version)
+            cmake_minimum_version = CMakeVersion(arg)
 
     convert()
 

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -1996,6 +1996,7 @@ def main(argv):
     global cmake_automoc
     global generate_comments
     global cmake_maximum_version
+    global cmake_minimum_version
     
     # Updating the CMake version info prior to handling arguments to ensure the values are properly set.
     update_version_info()

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -1623,17 +1623,24 @@ def convert():
     cmake_file.write("project({0})\n".format(project_working_directory))
 
     sorted_options = sorted(options.items(), key=lambda x: x[1].get_name(), reverse=False)
+    
     for option in sorted_options:
         option[1].finalize()
-        if generate_comments:
-            cmake_file.write("# Option to {0}\n".format(option[1].get_description()))
 
-        cmake_file.write(
-            "option( {0} \"{1}\" {2} )\n".format(
-                option[1].get_name(), 
-                replace_quotes(option[1].get_description()),
-                option[1].get_status())
-            )
+        # Dynamically sanitizing the option's name and description to remove unparsed Autotools tags.
+        clean_name = remove_garbage(option[1].get_name())
+        clean_desc = remove_garbage(option[1].get_description())
+
+        if generate_comments:
+            cmake_file.write("# Option to {0}\n".format(clean_desc))
+
+        # The previous implementation contained lackluster coverage, this newer implementation is significantly more robust!
+        cmake_file.write("option( {0} \"{1}\" {2} )\n".format(
+            clean_name,
+            replace_quotes(clean_desc),
+            option[1].get_status())
+        )
+
         if more_newlines:
             cmake_file.write("\n")
 

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -417,11 +417,7 @@ def get_latest_cmake_version():
 ########################################################################################################################
 def update_version_info():
     global cmake_maximum_version
-    global cmake_minimum_version
     global cmake_installed_version
-
-    # the minimum version of CMake the converted project will support
-    cmake_minimum_version = "2.8"
 
     # retrieving the latest version of CMake from their official Github repository
     # the maximimum version of CMake currently released. validate_cmake_version

--- a/auto2cmake.py
+++ b/auto2cmake.py
@@ -236,9 +236,9 @@ def count_parentheses(line):
 ########################################################################################################################
 # Replaces the quotes with escaped quotes to be put in the CMakeLists.txt
 ########################################################################################################################
-def replace_quotes(a):
-    a = a.replace('\"', '\\"')
-    return a
+def replace_quotes(value):
+    value = value.replace('\"', '\\"')
+    return value
 
 
 def get_library_for_name(name):

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -24,10 +24,23 @@ def run_command(command: str, cwd=cwd, packages_to_check=[]):
     return result
 
 def run_test(repo_url: str, project_name, packages_to_check: List[str], test_number: int) -> bool:
+
     print(f"Running Test #{test_number}\n")
 
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    project_root = os.path.join(repo_root, project_name)
     
+    if (os.path.exists(project_root)):
+        print(f"Deleting old test artifact at: {repo_root}")
+        try:
+            shutil.rmtree(project_root)
+            print("Deleted old test artifact")
+        except Exception as e:
+            print("Unable to remove old test artifacts.")
+            print("Please delete the directory manually.")
+            print(f"Error Log: {e}")
+
     print(f"Action 1/5: Cloning the repository from: {repo_url}\n")
 
     res = run_command(command=f"git clone {repo_url}", packages_to_check=["git"])

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -3,11 +3,11 @@ import sys
 sys.dont_write_bytecode = True
 
 import os, subprocess, shutil
-from typing import List
+from typing import List, Optional
 
 cwd = os.getcwd()
 
-def run_command(command: str, cwd=cwd, packages_to_check=[]):
+def run_command(command: str, cwd=cwd, packages_to_check=[], command_should_fail: bool = False, capture_output: bool = True):
     for package in packages_to_check:
 
         if not shutil.which(package):
@@ -16,16 +16,16 @@ def run_command(command: str, cwd=cwd, packages_to_check=[]):
     
     result = subprocess.run(args=command, shell=True, capture_output=True, text=True, cwd=cwd)
 
-    if result.returncode != 0:
-        print(f"Command failed with return code {result.returncode}")
-        print(f"STDOUT: {result.stdout}")
-        print(f"STDERR: {result.stderr}")
+    if result.returncode != 0 and not command_should_fail:
+        print(f"Command failed with return code: {result.returncode}")
+        print(result.stdout)
+        print(result.stderr)
 
     return result
 
-def run_test(repo_url: str, project_name, packages_to_check: List[str], test_number: int) -> bool:
-
-    print(f"Running Test #{test_number}\n")
+def run_test(repo_url: str, project_name, packages_to_check: List[str], test_number: int, cmake_version: Optional[str], test_info: str = "Not Provided", test_should_fail: bool = False) -> bool:
+    print(f"Running Test #{test_number}")
+    print(f"Test Description: {test_info}\n")
 
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -35,11 +35,11 @@ def run_test(repo_url: str, project_name, packages_to_check: List[str], test_num
         print(f"Deleting old test artifact at: {repo_root}")
         try:
             shutil.rmtree(project_root)
-            print("Deleted old test artifact")
+            print("Deleted old test artifact.\n")
         except Exception as e:
             print("Unable to remove old test artifacts.")
             print("Please delete the directory manually.")
-            print(f"Error Log: {e}")
+            print(f"Error Log: {e}\n")
 
     print(f"Action 1/5: Cloning the repository from: {repo_url}\n")
 
@@ -64,15 +64,30 @@ def run_test(repo_url: str, project_name, packages_to_check: List[str], test_num
             if file == "CMakeLists.txt":
                 os.remove(os.path.join(root, file))
 
-    print(f"Action 3/5: Running auto2cmake.py for {project_name}\n")
 
-    # Using -d to specify the directory
-    res = run_command(f"python3 {auto2cmake_py} -d {project_path}")
+    # Using -d to specify the working directory.
+    test_command = f"python3 {auto2cmake_py} -d {project_path}"
+    
+    # Using -v to specify a CMake version override.
+    test_command += f" -v {cmake_version}" if cmake_version is not None else test_command
+
+    
+    print(f"Action 3/5: Running auto2cmake.py for {project_name}")
+    print(f"Command: {test_command}\n")
+    
+    res = run_command(test_command, command_should_fail=test_should_fail)
+
     if res.returncode != 0:
-        print("auto2cmake.py failed.")
-        sys.exit(1)
+        # Handling the results of the test depending on the value passed to the parameter "test_should_fail"
+        message_prefix = "SUCCESS: " if test_should_fail else "FAILURE: "
+        message = "Test passed!\n\n" if test_should_fail else "Execution of auto2cmake.py failed.\n\n"
+        
+        print(message_prefix + message)
+        return test_should_fail
 
-    print(f"Action 4/5: Attempting to configure {project_name} using CMake\n")
+    cmake_version_string = "CMake" + f" {cmake_version}" if cmake_version is not None else ""
+    
+    print(f"Action 4/5: Attempting to configure {project_name} using {cmake_version_string}\n")
     build_dir = os.path.join(cwd, f"{project_name}_build_test")
     if os.path.exists(build_dir):
         shutil.rmtree(build_dir)
@@ -82,9 +97,9 @@ def run_test(repo_url: str, project_name, packages_to_check: List[str], test_num
     res = run_command(f"cmake -S {project_path} -B {build_dir}")
     
     if res.returncode == 0:
-        print(f"SUCCESS: {project_name} configured with CMake!\n")
+        print(f"SUCCESS: {project_name} configured with {cmake_version_string}!\n")
     else:
-        print("FAILURE: CMake configuration failed.\n")
+        print(f"FAILURE: Unable to configure {project_name} using {cmake_version_string}.\n")
 
     print("Action 5/5: Removing build artifacts associated with this test.\n")
     shutil.rmtree(project_path)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -18,7 +18,9 @@ if __name__ == "__main__":
             repo_url="https://github.com/gpg/gnupg", 
             project_name="gnupg", 
             packages_to_check=["git"], 
-            test_number=1
+            test_number=1,
+            test_info="Testing compatibility with gnupg using a supported legacy version of CMake (3.1)",
+            cmake_version="3.1"
         )
     },
 
@@ -31,9 +33,44 @@ if __name__ == "__main__":
             repo_url="https://github.com/python/cpython", 
             project_name="cpython", 
             packages_to_check=["git"],
-            test_number=2
+            test_number=2,
+            test_info="Testing compatibility with cpython, which caused issues in older releases of auto2cmake.",
+            cmake_version="3.28.3"
         )
-    }
+    },
+
+    {
+        "args": {
+            "repo_url": "https://github.com/gpg/gnupg", 
+            "project_name": "gnupg"
+        },
+        "result": run_test(
+            repo_url="https://github.com/gpg/gnupg", 
+            project_name="gnupg", 
+            packages_to_check=["git"],
+            test_number=3,
+            test_info="Testing the version parsing logic against an unsupported version of CMake (2.7)",
+            cmake_version="2.7",
+            test_should_fail=True
+        )
+    },
+
+    {
+        "args": {
+            "repo_url": "https://github.com/gpg/gnupg", 
+            "project_name": "gnupg"
+        },
+        "result": run_test(
+            repo_url="https://github.com/gpg/gnupg", 
+            project_name="gnupg", 
+            packages_to_check=["git"],
+            test_number=4,
+            test_info="Testing the version parsing logic against an unreleased version of CMake (6.9)",
+            cmake_version="6.9",
+            test_should_fail=True
+        )
+    },
+
     ]
     
     for response in tests:


### PR DESCRIPTION
# Logic Changes 
- Defined `cmake_minimum_version` as `"2.8"`.
    - For more information, see [line 265](https://github.com/Static-Codes/autocmake/blob/3964ff8c957cbc350862124a5883a03b424ed270/auto2cmake.py#L265).
  
- Added class `CMakeVersion` to manage the all parsing operations associated with a CMake version string(s).

- Added a flag for the user to define their desired version WITHOUT explicitly increasing `cmake_minimum_version`.
    - `-v <VERSION>`
    - `--version=<VERSION>`

- Added logic to resolve the latest version of CMake from the official [Kitware Mirror Repository](https://github.com/Kitware/CMake) . This parsing uses `urllib` to adhere to the portability requirements of auto2cmake. Finally, a `CMakeVersion` object is created at `cmake_maximum_version`

- Added `cmake_installed_version` which will hold either `None` (default) or an instance of `CMakeVersion` containing the `full_version` (ie. "3.28.1") and the associated values for `Major`, `Minor`, `Build`.

- Added logic to delete old build artifacts for potentially failed tests from previous runs in `tests/functions.py`

- Added negative test logic in `tests/functions.py`

- Refactored improper sanitization logic that would sometimes cause an inserted option to not properly closed.

- Refined comparison operations between two objects of class `CMakeVersion`

# Formatting and Quality of Life
- Added more descriptive variable names and comments.

- Moved classes above global variables to allow for better runtime validation.
